### PR TITLE
Remove redundant variable setting

### DIFF
--- a/initcpio/hooks/dock0
+++ b/initcpio/hooks/dock0
@@ -11,10 +11,10 @@ dock0_mount_handler() {
         local defaultroot="/dev/sda"
     fi
 
-    local root="${root:=${defaultroot}}"
-    local basepath="${basepath:=/run/vm}"
-    local rootfspath="${rootfspath:=latest/vm_root}"
-    local cowspace="${cowspace:=/dev/mapper/luks-cowspace}"
+    : ${root:=${defaultroot}}
+    : ${basepath:=/run/vm}
+    : ${rootfspath:=latest/vm_root}
+    : ${cowspace:=/dev/mapper/luks-cowspace}
 
     local lower="lowerdir=$basepath/fs"
     local upper="upperdir=$basepath/cowspace/upper"

--- a/initcpio/hooks/lvm-dock0
+++ b/initcpio/hooks/lvm-dock0
@@ -27,8 +27,8 @@ run_earlyhook() {
         local defaultpv="/dev/sdb"
     fi
 
-    local vg="${vg:=dock0}"
-    local pv="${pv:=${defaultpv}}"
+    : ${vg:=dock0}
+    : ${pv:=${defaultpv}}
 
     mkdir /run/lvm
     lvmetad


### PR DESCRIPTION
`local var=${var:=thing}` is redundant, because `${var:=thing}` sets var
to thing if var is unset already; the line still needs to be a
statement, though, so use : for this purpose.